### PR TITLE
Replace curb with mechanize for HTTP requests

### DIFF
--- a/bank_scrap.gemspec
+++ b/bank_scrap.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', "~> 0.19"
   spec.add_dependency 'nokogiri', "~> 1.6"
   spec.add_dependency 'execjs', "~> 2.2"
-  spec.add_dependency 'curb', "~> 0.8"
+  spec.add_dependency 'mechanize', "~> 2.7.3"
   spec.add_dependency 'activesupport', "~> 4.1"
   spec.add_dependency 'rmagick', '~> 2.2', '>= 2.2.2'
 end

--- a/lib/bank_scrap/bank.rb
+++ b/lib/bank_scrap/bank.rb
@@ -50,7 +50,6 @@ module BankScrap
         mechanize.user_agent = WEB_USER_AGENT
         mechanize.agent.http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         mechanize.log = Logger.new(STDOUT) if @debug
-        mechanize.set_proxy('localhost', 8888) 
       end
 
       @headers = {}

--- a/lib/bank_scrap/bank.rb
+++ b/lib/bank_scrap/bank.rb
@@ -14,11 +14,11 @@ module BankScrap
     end
 
     def post(url, fields)
-      @http.post(url, fields).body
+      @http.post(url, fields, @headers).body
     end
 
     def put(url, fields)
-      @http.put(url, fields).body
+      @http.put(url, fields, @headers).body
     end
 
     # Sets temporary HTTP headers, execute a code block
@@ -46,7 +46,7 @@ module BankScrap
     end
 
     def initialize_connection
-      @http = Mechanize.new do |mechanize| 
+      @http = Mechanize.new do |mechanize|
         mechanize.user_agent = WEB_USER_AGENT
         mechanize.agent.http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         mechanize.log = Logger.new(STDOUT) if @debug

--- a/lib/bank_scrap/bank.rb
+++ b/lib/bank_scrap/bank.rb
@@ -1,66 +1,59 @@
-require 'curb'
+require 'mechanize'
+require 'logger'
 
 module BankScrap
   class Bank
 
     WEB_USER_AGENT = 'Mozilla/5.0 (Linux; Android 4.2.1; en-us; Nexus 4 Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'
+    attr_accessor :headers
 
     private
 
     def get(url)
-      @curl.url = url
-      @curl.get
-
-      @curl.body_str
+      @http.get(url).body
     end
 
     def post(url, fields)
-      @curl.url = url
-
-      # If hash, transform to Curl::PostField objects
-      if fields.is_a? Hash
-        fields = fields.collect {|key, value| Curl::PostField.content(key, value)}
-      end
-
-      @curl.post(fields)
-      @curl.body_str
+      @http.post(url, fields).body
     end
 
     def put(url, fields)
-      @curl.url = url
-
-      @curl.put(fields)
-      @curl.body_str
+      @http.put(url, fields).body
     end
 
-    def set_header(name, value)
-      @curl.headers[name] = value
+    # Sets temporary HTTP headers, execute a code block
+    # and resets the headers
+    def with_headers(tmp_headers)
+      current_headers = @headers
+      set_headers(tmp_headers)
+      yield
+    ensure
+      set_headers(current_headers)
     end
+
 
     def set_headers(headers)
-      headers.each { |key, value| set_header(key, value) }
+      @headers.merge! headers
+      @http.request_headers = @headers
     end
 
-    def get_headers
-      @curl.header_str
-    end
 
     def initialize_cookie(url)
       log 'Initialize cookie'
 
-      @curl.url = url
-      @curl.get
-
-      @curl.body_str
+      @http.url = url
+      @http.get(url).body
     end
 
     def initialize_connection
-      @curl = Curl::Easy.new
-      @curl.follow_location = true
-      @curl.ssl_verify_peer = false
-      @curl.verbose = true if @debug
-      @curl.enable_cookies = true
-      @curl.headers["User-Agent"] = WEB_USER_AGENT
+      @http = Mechanize.new do |mechanize| 
+        mechanize.user_agent = WEB_USER_AGENT
+        mechanize.agent.http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        mechanize.log = Logger.new(STDOUT) if @debug
+        mechanize.set_proxy('localhost', 8888) 
+      end
+
+      @headers = {}
     end
 
     def log(msg)

--- a/lib/bank_scrap/version.rb
+++ b/lib/bank_scrap/version.rb
@@ -1,3 +1,3 @@
 module BankScrap
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
As explained on #9, `curb` has some bugs. After trying multiple libraries such as `rest-client` or `httparty`, @raulmarcosl and me we've decided to switch to Mechanize, which behaves more like a browser and has built-in support for cookie jars (i.e. when it receives a set-cookie header, it'll send those cookies in the next request).

We've introduced a new method `with_headers` on `Bank` that allows to execute a code block (probably an HTTP request) with some HTTP headers only for that request.

BBVA and ING are working on this branch. We need to test bankinter /cc @ismaGNU 